### PR TITLE
Remove `srcs_version` and `python_version` attributes, as they alread…

### DIFF
--- a/jmp/BUILD
+++ b/jmp/BUILD
@@ -19,7 +19,6 @@ exports_files(["LICENSE"])
 py_library(
     name = "jmp",
     srcs = ["__init__.py"],
-    srcs_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
         "//jmp/_src:loss_scale",

--- a/jmp/_src/BUILD
+++ b/jmp/_src/BUILD
@@ -10,7 +10,6 @@ licenses(["notice"])
 jmp_py_library(
     name = "loss_scale",
     srcs = ["loss_scale.py"],
-    srcs_version = "PY3",
     deps = [
         # pip: jax
         # pip: numpy
@@ -20,8 +19,6 @@ jmp_py_library(
 jmp_py_test(
     name = "loss_scale_test",
     srcs = ["loss_scale_test.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":loss_scale",
         # pip: absl/testing:absltest
@@ -34,7 +31,6 @@ jmp_py_test(
 jmp_py_library(
     name = "policy",
     srcs = ["policy.py"],
-    srcs_version = "PY3",
     deps = [
         # pip: jax
         # pip: numpy
@@ -44,8 +40,6 @@ jmp_py_library(
 jmp_py_test(
     name = "policy_test",
     srcs = ["policy_test.py"],
-    python_version = "PY3",
-    srcs_version = "PY3",
     deps = [
         ":policy",
         # pip: absl/testing:absltest

--- a/jmp/_src/loss_scale.py
+++ b/jmp/_src/loss_scale.py
@@ -116,11 +116,11 @@ class DynamicLossScale:
   ...   # conditionally update params using grads
   """
   loss_scale: jnp.ndarray
-  counter: jnp.ndarray = dataclasses.field(
+  counter: jnp.ndarray = dataclasses.field(  # pyrefly: ignore[bad-assignment]
       default_factory=lambda: np.zeros([], np.int32))
   period: int = 2000
   factor: int = 2
-  min_loss_scale: jnp.ndarray = dataclasses.field(
+  min_loss_scale: jnp.ndarray = dataclasses.field(  # pyrefly: ignore[bad-assignment]
       default_factory=lambda: np.ones([], np.float32))
 
   def __post_init__(self) -> None:


### PR DESCRIPTION
…y default to `"PY3"`

PiperOrigin-RevId: 721258489